### PR TITLE
Contribution to 821

### DIFF
--- a/pkg/3scale/amp/component/system.go
+++ b/pkg/3scale/amp/component/system.go
@@ -205,10 +205,9 @@ func (system *System) buildSystemBaseEnv() []v1.EnvVar {
 
 	result = append(result, system.SystemRedisEnvVars()...)
 	result = append(result, system.BackendRedisEnvVars()...)
-	bckListenerApicastRouteEnv := helper.EnvVarFromSecret("APICAST_BACKEND_ROOT_ENDPOINT", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
 	bckServiceEndpointEnv := helper.EnvVarFromSecret("BACKEND_URL", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerServiceEndpointFieldName)
 	bckPublicRouteEndpointEnv := helper.EnvVarFromSecret("BACKEND_PUBLIC_URL", BackendSecretBackendListenerSecretName, BackendSecretBackendListenerRouteEndpointFieldName)
-	result = append(result, bckListenerApicastRouteEnv, bckServiceEndpointEnv, bckPublicRouteEndpointEnv)
+	result = append(result, bckServiceEndpointEnv, bckPublicRouteEndpointEnv)
 
 	smtpEnvSecretEnvs := system.getSystemSMTPEnvsFromSMTPSecret()
 	result = append(result, smtpEnvSecretEnvs...)

--- a/pkg/3scale/amp/operator/system_reconciler.go
+++ b/pkg/3scale/amp/operator/system_reconciler.go
@@ -87,6 +87,8 @@ func (r *SystemReconciler) Reconcile() (reconcile.Result, error) {
 		reconcilers.DeploymentConfigRemoveDuplicateEnvVarMutator,
 		// 3scale 2.13 -> 2.14
 		upgrade.SphinxAddressReference,
+		// 3scale 2.13 -> 2.14
+		upgrade.SystemBackendUrls,
 	}
 
 	if r.apiManager.Spec.System.AppSpec.Replicas != nil {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -289,13 +289,11 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/pkg/upgrade/upgrade_system_backend_urls_2.14.go
+++ b/pkg/upgrade/upgrade_system_backend_urls_2.14.go
@@ -11,12 +11,20 @@ func SystemBackendUrls(desired, existing *appsv1.DeploymentConfig) (bool, error)
 	var changed bool
 
 	// Remove old env var
-	oldVarRemoved := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_ROUTE")
+	tmpChanged := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "APICAST_BACKEND_ROOT_ENDPOINT")
+	changed = changed || tmpChanged
+
+	// Remove old env var
+	tmpChanged = reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_ROUTE")
+	changed = changed || tmpChanged
 
 	// Add new env vars
-	newVar1Added := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_URL")
-	newVar2Added := reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_PUBLIC_URL")
-	changed = oldVarRemoved || newVar1Added || newVar2Added
+	tmpChanged = reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_URL")
+	changed = changed || tmpChanged
+
+	// Add new env vars
+	tmpChanged = reconcilers.DeploymentConfigEnvVarReconciler(desired, existing, "BACKEND_PUBLIC_URL")
+	changed = changed || tmpChanged
 
 	return changed, nil
 }


### PR DESCRIPTION
### What

* Deleted `system-app` env var `APICAST_BACKEND_ROOT_ENDPOINT`
* Deleted `system-app` env var `BACKEND_ROUTE`
* Add `system-app` env var `BACKEND_URL`:  `service_endpoint` value from `backend-listener` secret (i.e. `http://backend-listener:3000`). Note `/internal` is no longer provided. That will be added by System.
* Add `system-app` env var `BACKEND_PUBLIC_URL`:  `route_endpoint` value from `backend-listener` secret (i.e. `https://backend-3scale.apps.mycluster.com`). 
* Upgrade procedure from the previous release

### Verification steps

* Requires openshift (oc CLI) session 

#### New deployment

* Create new project
```
oc new-project 3scale-testing-new-deployment
```
* Checkout this branch and run the operator
```
make install
make run
```
* Deploy 3scale 
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: test01.example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check the system-app deployment no longer has `APICAST_BACKEND_ROOT_ENDPOINT` or `BACKEND_ROUTE` env vars
```
# It should report empty
❯ k get dc system-app -o yaml | grep -A 1  APICAST_BACKEND_ROOT_ENDPOINT

# It should report empty
❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
```

* Check the system-app deployment has the `BACKEND_URL` env var from the  `backend-listener` secret and  `service_endpoint` field
```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_URL
          - name: BACKEND_URL
            valueFrom:
              secretKeyRef:
                key: service_endpoint
                name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
```

It is replicated 4 times in 4 different deployment: pre-hook pod deployment container and `system-master`, `system-provider`, `system-developer` containers.

* Check the system-app deployment has the `BACKEND_PUBLIC_URL` env var from the  `backend-listener` secret and  `route_endpoint` field

```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_PUBLIC_URL
          - name: BACKEND_PUBLIC_URL
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
```
The `backend-listener` secret values

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.service_endpoint}" | base64 --decode
http://backend-listener:3000
```

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.route_endpoint}" | base64 --decode
https://backend-3scale.example.net
```
#### Upgrade from 2.13

* Create new project
```
oc new-project 3scale-testing-upgrade
```

* Checkout current [master](https://github.com/3scale/3scale-operator/commit/8cc98759cc1ee761bf5fb811fb2dcfccf122b71a) branch and run the operator
```
git checkout 8cc98759cc1ee761bf5fb811fb2dcfccf122b71a
make install
make run
```
* Deploy 3scale from current master
  * no need to specify S3 credentials
  * `wildcardDomain` must be something valid (only if it is going to be used later). Usually `${PROJECT_NAME}.apps.${CLUSTER_DOMAIN}`

```yaml
k apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  creationTimestamp: null
  name: aws-auth
stringData:
  AWS_ACCESS_KEY_ID: testID
  AWS_SECRET_ACCESS_KEY: testkey
  AWS_BUCKET: testbucket
  AWS_REGION: us-east-1
type: Opaque
EOF
```
```yaml
k apply -f - <<EOF
---
apiVersion: apps.3scale.net/v1alpha1
kind: APIManager
metadata:
  name: apimanager1
spec:
  wildcardDomain: test01.example.net
  resourceRequirementsEnabled: false
  system:
    fileStorage:
      simpleStorageService:
        configurationSecretRef:
          name: aws-auth
EOF
```
* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 

* Check the system-app deployment has the `APICAST_BACKEND_ROOT_ENDPOINT` and `BACKEND_ROUTE` env var. Note that `BACKEND_ROUTE` is set to `http://backend-listener:3000/internal/`

```
❯ k get dc system-app -o yaml | grep -A 4  APICAST_BACKEND_ROOT_ENDPOINT
          - name: APICAST_BACKEND_ROOT_ENDPOINT
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: APICAST_BACKEND_ROOT_ENDPOINT
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener

❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
          - name: BACKEND_ROUTE
            value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
--
        - name: BACKEND_ROUTE
          value: http://backend-listener:3000/internal/
```

* Let's run upgrade. Checkout this PR's branch and run the operator
```
git checkout <new-branch-name>
make run
```
The upgrade should happen automatically

* wait for deployment to be ready
```
oc wait --for=condition=available apimanager/apimanager1 --timeout=-1s
apimanager.apps.3scale.net/apimanager1 condition met
```
The above "wait" ensures the pods are up and running. 
* All the deployments should be `ready`. Note the `system-app` deployment as it should have been rolled out automatically.
```yaml
❯ k get apimanager apimanager1 -o jsonpath='{.status.deployments}' | yq e -P
ready:
  - apicast-production
  - apicast-staging
  - backend-cron
  - backend-listener
  - backend-redis
  - backend-worker
  - system-app
  - system-memcache
  - system-mysql
  - system-redis
  - system-searchd
  - system-sidekiq
  - zync
  - zync-database
  - zync-que
```
* Check the system-app deployment no longer has `APICAST_BACKEND_ROOT_ENDPOINT` or `BACKEND_ROUTE` env vars
```
# It should report empty
❯ k get dc system-app -o yaml | grep -A 1  APICAST_BACKEND_ROOT_ENDPOINT

# It should report empty
❯ k get dc system-app -o yaml | grep -A 1 BACKEND_ROUTE
```

* Check the system-app deployment has the `BACKEND_URL` env var from the  `backend-listener` secret and  `service_endpoint` field
```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_URL
          - name: BACKEND_URL
            valueFrom:
              secretKeyRef:
                key: service_endpoint
                name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
--
        - name: BACKEND_URL
          valueFrom:
            secretKeyRef:
              key: service_endpoint
              name: backend-listener
```

It is replicated 4 times in 4 different deployment: pre-hook pod deployment container and `system-master`, `system-provider`, `system-developer` containers.

* Check the system-app deployment has the `BACKEND_PUBLIC_URL` env var from the  `backend-listener` secret and  `route_endpoint` field

```
❯ k get dc system-app -o yaml | grep -A 4 BACKEND_PUBLIC_URL
          - name: BACKEND_PUBLIC_URL
            valueFrom:
              secretKeyRef:
                key: route_endpoint
                name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
--
        - name: BACKEND_PUBLIC_URL
          valueFrom:
            secretKeyRef:
              key: route_endpoint
              name: backend-listener
```
The `backend-listener` secret values

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.service_endpoint}" | base64 --decode
http://backend-listener:3000
```

```
❯ kubectl get secret backend-listener -o jsonpath="{.data.route_endpoint}" | base64 --decode
https://backend-3scale.example.net
```
